### PR TITLE
Replaced FloatIndividual with AbstractESIndividual

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,11 @@ version = "0.1.0"
 
 [deps]
 Cambrian = "7f27c84d-2d74-42e5-be5f-94f6748267f3"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 Cambrian = "0.2.1"

--- a/src/EvolutionaryStrategies.jl
+++ b/src/EvolutionaryStrategies.jl
@@ -6,6 +6,7 @@ using LinearAlgebra
 
 abstract type ESState end
 
+include("individual.jl")
 include("exponential_nes.jl")
 include("separable_nes.jl")
 

--- a/src/exponential_nes.jl
+++ b/src/exponential_nes.jl
@@ -35,25 +35,25 @@ end
 mutable struct xNES <: Cambrian.AbstractEvolution
     config::NamedTuple
     logger::CambrianLogger
-    population::Array{FloatIndividual}
-    elites::Array{FloatIndividual}
+    population::Array{AbstractESIndividual}
+    elites::Array{AbstractESIndividual}
     state::xNESState
     fitness::Function
     gen::Int
 end
 
-function xnes_init(cfg::NamedTuple, state::ESState)
-    population = Array{FloatIndividual}(undef, cfg.n_population)
+function xnes_init(cfg::NamedTuple, state::ESState; T::Type=ESIndividual)
+    population = Array{AbstractESIndividual}(undef, cfg.n_population)
     for i in 1:cfg.n_population
         genes = state.μ .+ state.σ .* (state.B * view(state.s, :, i))
-        population[i] = FloatIndividual(genes, -Inf*ones(cfg.d_fitness))
+        population[i] = T(genes, -Inf*ones(cfg.d_fitness))
     end
     population
 end
 
-function xNES(cfg::NamedTuple, fitness::Function, state::xNESState; logfile=string("logs/", cfg.id, ".csv"))
+function xNES(cfg::NamedTuple, fitness::Function, state::xNESState; T::Type=ESIndividual ,logfile=string("logs/", cfg.id, ".csv"))
     logger = CambrianLogger(logfile)
-    population = xnes_init(cfg, state)
+    population = xnes_init(cfg, state, T=T)
     elites = deepcopy([population[i] for i in 1:cfg.n_elite])
     xNES(cfg, logger, population, elites, state, fitness, 0)
 end

--- a/src/exponential_nes.jl
+++ b/src/exponential_nes.jl
@@ -64,11 +64,11 @@ Will use a random starting point using N(0, 1)
 If cfg contains keys from snes_config, these will be used
 To provide initial state, see xNES(cfg, fitness, state)
 """
-function xNES(cfg::NamedTuple, fitness::Function; logfile=string("logs/", cfg.id, ".csv"))
+function xNES(cfg::NamedTuple, fitness::Function;  T::Type=ESIndividual, logfile=string("logs/", cfg.id, ".csv"))
     logger = CambrianLogger(logfile)
     cfg = merge(xnes_config(cfg.n_genes), cfg)
     state = xNESState(cfg.n_genes, cfg.n_population)
-    xNES(cfg, fitness, state; logfile=logfile)
+    xNES(cfg, fitness, state; T=T, logfile=logfile)
 end
 
 "generate next population"

--- a/src/individual.jl
+++ b/src/individual.jl
@@ -1,0 +1,36 @@
+import Cambrian.get_config
+using YAML
+using Dates
+
+export ESIndividual, AbstractESIndividual, get_config
+
+abstract type AbstractESIndividual <: Cambrian.Individual end
+
+"FloatIndividual : example Individual class using a floating point genotype in [0, 1]"
+struct ESIndividual <: AbstractESIndividual
+    genes::Array{Float64}
+    fitness::Array{Float64}
+end
+
+function ESIndividual(cfg::NamedTuple)
+    ESIndividual(rand(cfg.n_genes), -Inf*ones(cfg.d_fitness))
+end
+
+function ESIndividual(st::String)
+    dict = ind_parse(st)
+    ESIndividual(Float64.(dict["genes"]), Float64.(dict["fitness"]))
+end
+
+## utils
+
+function Cambrian.get_config(cfg_file::String; kwargs...)
+    cfg = YAML.load_file(cfg_file)
+    for (k, v) in kwargs
+        cfg[String(k)] = v
+    end
+    # generate id, use date if no existing id
+    if ~(:id in keys(cfg))
+        cfg["id"] = replace(string(Dates.now()), r"[]\.:]" => "_")
+    end
+    get_config(cfg)
+end

--- a/src/separable_nes.jl
+++ b/src/separable_nes.jl
@@ -59,11 +59,11 @@ Will use a random starting point using N(0, 1)
 If cfg contains keys from snes_config, these will be used
 To provide initial state, see sNES(cfg, fitness, state)
 """
-function sNES(cfg::NamedTuple, fitness::Function; logfile=string("logs/", cfg.id, ".csv"))
+function sNES(cfg::NamedTuple, fitness::Function; T::Type=ESIndividual, logfile=string("logs/", cfg.id, ".csv"))
     logger = CambrianLogger(logfile)
     cfg = merge(snes_config(cfg.n_genes), cfg)
     state = sNESState(cfg.n_genes, cfg.n_population)
-    sNES(cfg, fitness, state; logfile=logfile)
+    sNES(cfg, fitness, state; T=T, logfile=logfile)
 end
 
 "generate next population"

--- a/src/separable_nes.jl
+++ b/src/separable_nes.jl
@@ -30,25 +30,25 @@ end
 mutable struct sNES <: Cambrian.AbstractEvolution
     config::NamedTuple
     logger::CambrianLogger
-    population::Array{FloatIndividual}
-    elites::Array{FloatIndividual}
+    population::Array{AbstractESIndividual}
+    elites::Array{AbstractESIndividual}
     state::sNESState
     fitness::Function
     gen::Int
 end
 
-function snes_init(cfg::NamedTuple, state::ESState)
-    population = Array{FloatIndividual}(undef, cfg.n_population)
+function snes_init(cfg::NamedTuple, state::ESState; T::Type=ESIndividual)
+    population = Array{AbstractESIndividual}(undef, cfg.n_population)
     for i in 1:cfg.n_population
         genes = state.μ .+ state.σ .* view(state.s, :, i)
-        population[i] = FloatIndividual(genes, -Inf*ones(cfg.d_fitness))
+        population[i] = T(genes, -Inf*ones(cfg.d_fitness))
     end
     population
 end
 
-function sNES(cfg::NamedTuple, fitness::Function, state::sNESState; logfile=string("logs/", cfg.id, ".csv"))
+function sNES(cfg::NamedTuple, fitness::Function, state::sNESState; T::Type=ESIndividual, logfile=string("logs/", cfg.id, ".csv"))
     logger = CambrianLogger(logfile)
-    population = snes_init(cfg, state)
+    population = snes_init(cfg, state, T=T)
     elites = deepcopy([population[i] for i in 1:cfg.n_elite])
     sNES(cfg, logger, population, elites, state, fitness, 0)
 end

--- a/test/individual.jl
+++ b/test/individual.jl
@@ -5,7 +5,7 @@ using Test
 cfg = get_config("test.yaml")
 
 @testset "Individual" begin
-    ind = FloatIndividual(cfg)
+    ind = ESIndividual(cfg)
     @test ind.fitness[1] == -Inf
 
     @test rosenbrock(ind)[1] < 0


### PR DESCRIPTION
Replaced FloatIndividual with AbstractESIndividual to make it possible to use other individual types in the evolution.
Default behavior with ESIndividual does not change.
Passing tests.
Replaced Cambrian's get_config to correct issue with "." in file names due to date formatting.